### PR TITLE
Update KendoGridBinder/KendoGrid.cs

### DIFF
--- a/KendoGridBinder/KendoGrid.cs
+++ b/KendoGridBinder/KendoGrid.cs
@@ -14,13 +14,16 @@ namespace KendoGridBinder
             var filtering = GetFiltering(request);
             var sorting = GetSorting(request);
 
-            total = query.Count();
+    		var tempQuery = query
+				.Where(filtering)
+				.OrderBy(sorting);
 
-            data = query
-                .Where(filtering)
-                .OrderBy(sorting)
-                .Skip(request.Skip)
-                .Take(request.Take);
+			total = tempQuery
+			    .Count();
+
+			data = tempQuery
+				.Skip(request.Skip)
+				.Take(request.Take);
         }
 
         public KendoGrid(KendoGridRequest request, IEnumerable<T> list)


### PR DESCRIPTION
When paginating the grid shows more pages than the filtered. In the previous version the "total" variable does not take into account the filter.
